### PR TITLE
Minor fixes

### DIFF
--- a/kernel/api/chario.c
+++ b/kernel/api/chario.c
@@ -6,11 +6,11 @@
 #include<api/chario.h>
 
 extern void int23_dispatch(void);
-static unsigned char buffer[256];
-static int echo_to_printer = 0;
+static char buffer[256];
+static bool echo_to_printer = false;
 static unsigned int linepos = 0;
 
-static int handle_control_c(char key) {
+static bool handle_control_c(char key) {
     switch (key) {
         case 'C'-'@':
             bios_putchar('^');
@@ -22,14 +22,14 @@ static int handle_control_c(char key) {
 
         case 'P'-'@':
             echo_to_printer = !echo_to_printer;
-            return 1;
+            return true;
 
         case 'S'-'@':
             key = bios_getchar();
             if ((key == 'C'-'@') || (key == 'P'-'@')) handle_control_c(key);
     }
 
-    return 0;
+    return false;
 }
 
 static unsigned int status(void) {
@@ -200,7 +200,7 @@ static uint8_t skip_to_char (const char far *oldbuf, uint8_t oldlen, uint8_t old
 void gets(void) {
     unsigned int i, count;
     /* get pointer to user input buffer containing previous input */
-    unsigned char far *oldbuf = FARPTR(last_sp->ds, last_sp->dx);
+    char far *oldbuf = FARPTR(last_sp->ds, last_sp->dx);
     /* get length of old input and new input */
     uint8_t newlen = oldbuf[0], oldlen = oldbuf[1];
     /* abort if buffer size is zero */

--- a/kernel/api/chario.c
+++ b/kernel/api/chario.c
@@ -234,7 +234,7 @@ void gets(void) {
 
                 /* delete character */
                 newpos--;
-                if (oldpos && (buffer[newpos] == oldbuf[oldpos - 1]))
+                if (oldpos)
                     oldpos--;
 
                 /* determine amount to backtrack */

--- a/kernel/lib/alloc.c
+++ b/kernel/lib/alloc.c
@@ -6,8 +6,8 @@
 #include<lib/alloc.h>
 
 extern symbol bss_end;
-static unsigned int memory_base;
-static unsigned int memory_end;
+static segment_t memory_base;
+static segment_t memory_end;
 static bool inited = false;
 static char memerror[] = "\r\nMemory allocation error\r\n";
 

--- a/kernel/lib/klib.c
+++ b/kernel/lib/klib.c
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include <ptrdef.h>
 #include <api/chario.h>
 #include <lib/klib.h>

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -1,3 +1,4 @@
+#include <stddef.h>
 #include <stdint.h>
 #include <ptrdef.h>
 #include <bios/io.h>

--- a/kernel/ptrdef.c
+++ b/kernel/ptrdef.c
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include <ptrdef.h>
 
 void far ** const ivt = 0;

--- a/kernel/startup/startup.asm
+++ b/kernel/startup/startup.asm
@@ -57,6 +57,11 @@ _start:
     mov sp, dsk_stack ; use I/O stack for initialization - (TODO using disk stack to test character I/O)
 
     sti
+    mov di, data_end ; clear BSS (which the legacy boot sector does not do)
+    mov cx, bss_end
+    sub cx, di
+    xor al, al
+    rep stosb
 
     call kmain
 


### PR DESCRIPTION
* Fixed a bug with the DOS buffered input command line editor.
* Made the BSS be cleared under the legacy boot sector.
* More consistent usage of type aliases.
* Added missing includes. I have no idea how it compiled prior to this.